### PR TITLE
Update README.windows.md

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -3,7 +3,7 @@
 * Install [.NET Framework 4.0](http://www.microsoft.com/download/en/details.aspx?id=17851) (if not installed yet)
 
 * Install [msysGit](http://code.google.com/p/msysgit/downloads/detail?name=Git-1.7.8-preview20111206.exe)
-  *  I recommend you to install in `C:\msysgit`
+  *  Change install location to `C:\msysgit` (location is hard-coded in the build scrits)
   *  Use default settings for all other questions during installation
 
 * _Clone step_: Open a Git console (available in Start Menu > Git > Git Bash). On the command line write
@@ -20,7 +20,7 @@
 
 * Copy the entire contents of the msysGit folder to `C:\SparkleShare\bin\msysgit`
 
-* _Build step_: Open a command shell (available in Start Menu > Accessories > Command Prompt) and execute
+* _Build step_: Open a command shell (available in Start Menu > Accessories > Command Prompt) and execute   (Note to Windows 7 x64 users: change the WinDirNet variable in build.cmd to "%WinDir%\Microsoft.NET\Framework64") 
 
         C:
         cd C:\SparkleShare


### PR DESCRIPTION
Tried building and running on Win7x64, and encountered a couple of hitches.
1. It's not just a suggestion that msysgit is installed in c:\msysgit, it's a requirement to use the current build scripts.
2.  The compilation is pretty fragile.  Unless you have the exactly correct combo of Framework architecture (x86 or x64) and Framework version (3.5 or 4.0.3xxxx), the compile will fail.  I toyed around with all four permutations before settling on the Error-free combo of Framework64 and v3.5 by tweaking the main build.cmd.  (Note: I'm no expert in windows programming, so I'm not sure how serious are the generated warnings resulting from using x64 libs.)

CSC : warning CS1607: Assembly generation -- Referenced assembly 'System.Data.dll' targets a different processor
CSC : warning CS1607: Assembly generation -- Referenced assembly 'mscorlib.dll' targets a different processor
CSC : warning CS1607: Assembly generation -- The version '0.4.2-258-g1048e9f' specified for the 'product version' is not in the normal 'major.minor.build.revision' format
